### PR TITLE
Added DSU /code local cache by downloading whole DSU content to disk

### DIFF
--- a/bootScripts/NodeThreadWorkerBootScript/DSUCodeFileCacheHandler.js
+++ b/bootScripts/NodeThreadWorkerBootScript/DSUCodeFileCacheHandler.js
@@ -1,0 +1,129 @@
+const fs = require("fs");
+const path = require("path");
+
+const readFileAsync = $$.promisify(fs.readFile.bind(fs));
+const writeFileAsync = $$.promisify(fs.writeFile.bind(this));
+const mkdirAsync = $$.promisify(fs.mkdir.bind(this));
+
+const pathExistsAsync = async (path) => {
+    try {
+        await $$.promisify(fs.access.bind(fs))(path);
+        return true;
+    } catch (error) {
+        return false;
+    }
+};
+
+function isFileInsideFolderStructure(file) {
+    return file.indexOf("/") !== -1;
+}
+
+class DSUCodeFileCacheHandler {
+    constructor(dsu, cacheFolderBasePath) {
+        this.dsu = dsu;
+        this.cacheFolderBasePath = cacheFolderBasePath;
+    }
+
+    async constructCache() {
+        const openDSU = require("opendsu");
+        const keySSISpace = openDSU.loadAPI("keyssi");
+        const resolver = openDSU.loadApi("resolver");
+
+        const mountedDSUs = await $$.promisify(this.dsu.listMountedDossiers)("/");
+
+        let codeFolderName = openDSU.constants.CODE_FOLDER;
+        if (codeFolderName[0] === "/") {
+            codeFolderName = codeFolderName.substring(1);
+        }
+        const codeMount = mountedDSUs.find((mount) => mount.path === codeFolderName);
+        const codeDSU = await $$.promisify(resolver.loadDSU)(codeMount.identifier);
+        const codeFiles = await $$.promisify(codeDSU.listFiles)("/");
+
+        // commenting out due to getAllVersions failing on Android
+        // const anchoringApi = openDSU.loadAPI("anchoring");
+        // const codeMountKeySSI = keySSISpace.parse(codeMount.identifier);
+        // const versions = await $$.promisify(anchoringApi.getAllVersions)(codeMountKeySSI);
+        // const lastVersion = versions[versions.length - 1];
+        // const currentVersionHashLinkSSI = lastVersion.getIdentifier();
+
+        // using codeMount.identifier instead of currentVersionHashLinkSSI
+        const cacheFolderPath = path.join(this.cacheFolderBasePath, codeMount.identifier);
+        this.cacheFolderPath = cacheFolderPath;
+
+        const readDSUFileAsync = $$.promisify(codeDSU.readFile);
+
+        const isHashLinkFolderAlreadyPresent = await pathExistsAsync(cacheFolderPath);
+
+        if (!isHashLinkFolderAlreadyPresent) {
+            console.log(`Creating cache folder for DSU ${codeMount.identifier}: ${cacheFolderPath}`);
+            try {
+                await mkdirAsync(cacheFolderPath, { recursive: true });
+            } catch (error) {
+                console.log(`Failed created cacheFolderPath ${cacheFolderPath}`, error);
+            }
+        }
+
+        const createdFoldersMap = {};
+        const availableFilesMap = {};
+
+        for (const codeFile of codeFiles) {
+            if (isFileInsideFolderStructure(codeFile)) {
+                const codeFolder = codeFile.substr(0, codeFile.lastIndexOf("/"));
+                if (!createdFoldersMap[codeFolder]) {
+                    try {
+                        await mkdirAsync(path.join(cacheFolderPath, codeFolder), { recursive: true });
+                    } catch (error) {
+                        if (error.code !== "EEXIST") {
+                            console.log(`Failed to create cache folder ${codeFolder}`, error);
+                        }
+                    }
+                    createdFoldersMap[codeFolder] = true;
+                }
+            }
+
+            try {
+                const filePath = path.join(cacheFolderPath, codeFile);
+
+                let mustWriteFile = true;
+                if (isHashLinkFolderAlreadyPresent) {
+                    mustWriteFile = !(await pathExistsAsync(filePath));
+                }
+
+                if (mustWriteFile) {
+                    const fileContent = await readDSUFileAsync(codeFile);
+                    await writeFileAsync(filePath, fileContent);
+                }
+
+                let relativeFilePath = codeFile;
+                if (relativeFilePath[0] !== "/") {
+                    relativeFilePath = `/${relativeFilePath}`;
+                }
+                availableFilesMap[relativeFilePath] = true;
+            } catch (error) {
+                console.log(`read ${codeFile} error`, error);
+            }
+        }
+
+        this.availableFilesMap = availableFilesMap;
+    }
+
+    async getFileContent(filePath) {
+        if (!this.availableFilesMap) {
+            // Strategy is still constructing cache
+            return null;
+        }
+
+        const fullPath = path.join(this.cacheFolderPath, filePath);
+        if (!this.availableFilesMap[filePath]) {
+            console.log(`File ${fullPath} not present inside DSU cache`);
+            return null;
+        }
+
+        console.log(`Serving file ${fullPath} from DSU cache`);
+        const fileContent = await readFileAsync(fullPath);
+
+        return fileContent;
+    }
+}
+
+module.exports = DSUCodeFileCacheHandler;

--- a/bootScripts/NodeThreadWorkerBootScript/DSUCodeFileCacheHandler.js
+++ b/bootScripts/NodeThreadWorkerBootScript/DSUCodeFileCacheHandler.js
@@ -38,16 +38,9 @@ class DSUCodeFileCacheHandler {
         const codeMount = mountedDSUs.find((mount) => mount.path === codeFolderName);
         const codeDSU = await $$.promisify(resolver.loadDSU)(codeMount.identifier);
         const codeFiles = await $$.promisify(codeDSU.listFiles)("/");
+        const lastVersion = $$.promisify(codeDSU.getLastHashLinkSSI)();
 
-        // commenting out due to getAllVersions failing on Android
-        // const anchoringApi = openDSU.loadAPI("anchoring");
-        // const codeMountKeySSI = keySSISpace.parse(codeMount.identifier);
-        // const versions = await $$.promisify(anchoringApi.getAllVersions)(codeMountKeySSI);
-        // const lastVersion = versions[versions.length - 1];
-        // const currentVersionHashLinkSSI = lastVersion.getIdentifier();
-
-        // using codeMount.identifier instead of currentVersionHashLinkSSI
-        const cacheFolderPath = path.join(this.cacheFolderBasePath, codeMount.identifier);
+        const cacheFolderPath = path.join(this.cacheFolderBasePath, lastVersion);
         this.cacheFolderPath = cacheFolderPath;
 
         const readDSUFileAsync = $$.promisify(codeDSU.readFile);
@@ -55,7 +48,7 @@ class DSUCodeFileCacheHandler {
         const isHashLinkFolderAlreadyPresent = await pathExistsAsync(cacheFolderPath);
 
         if (!isHashLinkFolderAlreadyPresent) {
-            console.log(`Creating cache folder for DSU ${codeMount.identifier}: ${cacheFolderPath}`);
+            console.log(`Creating cache folder for DSU ${lastVersion}: ${cacheFolderPath}`);
             try {
                 await mkdirAsync(cacheFolderPath, { recursive: true });
             } catch (error) {

--- a/bootScripts/NodeThreadWorkerBootScript/fileRequestHandler.js
+++ b/bootScripts/NodeThreadWorkerBootScript/fileRequestHandler.js
@@ -1,6 +1,6 @@
 const MimeType = require("../browser/util/MimeType");
 
-const handle = (dsu, req, res, seed, requestedPath) => {
+const handle = async (dsu, req, res, seed, requestedPath, dsuCodeFileCacheHandler) => {
     const { url } = req;
 
     console.log(`Handling request for file: ${requestedPath}`);
@@ -38,8 +38,19 @@ const handle = (dsu, req, res, seed, requestedPath) => {
         res.end(content);
     };
 
-    dsu.readFile(`/app${file}`, (err, fileContent) => {
+    dsu.readFile(`/app${file}`, async (err, fileContent) => {
         if (err) {
+            if(dsuCodeFileCacheHandler) {
+                try {
+                    const fileContent = await dsuCodeFileCacheHandler.getFileContent(file);
+                    if(fileContent) {
+                        return sendFile(fileContent);
+                    }                    
+                } catch (error) {
+                    console.log("An error has occurred while getting file from cache", file);
+                }
+            }
+
             dsu.readFile(`/code${file}`, (err, fileContent) => {
                 if (err) {
                     //console.log(`Error reading file /code${file}`, err);


### PR DESCRIPTION
When booting the CloudWallet worker, the DSU mounted at /code will be downloaded completely inside external-volume.

Some testing metrics:

### Before current implementation:

**Android emulator:**
147 requests
10.8 MB transferred
11.0 MB resources
**Finish: 19.95 s**
DOMContentLoaded: 1.20 s
Load: 1.32 s

**Windows Chrome:**
145 requests
10.8 MB transferred
11.0 MB resources
**Finish: 2.76 s**
DOMContentLoaded: 461 ms
Load: 470 ms

### With current implementation (when cache is fully constructed):

**Android emulator:**
147 requests
10.8 MB transferred
11.0 MB resources
**Finish: 9.01 s**
DOMContentLoaded: 1.11 s
Load: 1.14 s

**Windows Chrome:**
145 requests
10.8 MB transferred
11.0 MB resources
**Finish: 2.35 s**
DOMContentLoaded: 456 ms
Load: 510 ms
